### PR TITLE
Backfill missing lab metadata (6 files)

### DIFF
--- a/Instructions/01-create-account.md
+++ b/Instructions/01-create-account.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Create a vCore-based Azure Cosmos DB for MongoDB account using the Azure portal'
-    module: 'Module 1 - Get Started with vCore-based Azure Cosmos DB for MongoDB'
+  title: Create a vCore-based Azure Cosmos DB for MongoDB account using the Azure portal
+  module: Module 1 - Get Started with vCore-based Azure Cosmos DB for MongoDB
+  description: In this lab, we guide you through the process of creating a vCore-based Azure Cosmos DB for MongoDB account using the Azure portal. We walk you through the steps of setting up the Cosmos DB account, configuring the necessary settings, and preparing it for use. The focus is on understanding the different configuration options and how they affect the behavior and performance of the Cosmos DB. By the end of this lab, you have a fully configured Cosmos DB for MongoDB ready for data storage and retrieval.
+  duration: 108 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Cosmos DB
+    - Azure Portal
 ---
 
 In this lab, we guide you through the process of creating a vCore-based Azure Cosmos DB for MongoDB account using the Azure portal. We walk you through the steps of setting up the Cosmos DB account, configuring the necessary settings, and preparing it for use. The focus is on understanding the different configuration options and how they affect the behavior and performance of the Cosmos DB. By the end of this lab, you have a fully configured Cosmos DB for MongoDB ready for data storage and retrieval.

--- a/Instructions/02-migrate.md
+++ b/Instructions/02-migrate.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Migrate a MongoDB database to a vCore-based Azure Cosmos DB for MongoDB account'
-    module: 'Module 2 - Migrate to vCore-based Azure Cosmos DB for MongoDB'
+  title: Migrate a MongoDB database to a vCore-based Azure Cosmos DB for MongoDB account
+  module: Module 2 - Migrate to vCore-based Azure Cosmos DB for MongoDB
+  description: 'In this lab, you learn how to use the MongoDB native tools to migrate a MongoDB database to a vCore-based Azure Cosmos DB for MongoDB account. You use the following tools:'
+  duration: 100 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Cosmos DB
 ---
 
 Data migration is a critical step in the process of moving from an existing MongoDB database to a vCore-based Azure Cosmos DB for MongoDB account. While there are several ways to migrate a MongoDB database to a vCore-based Azure Cosmos DB for MongoDB account, this lab focuses on using the MongoDB native tools to migrate the database. The MongoDB native tools are the most common way to migrate a MongoDB database to another. Most MongoDB administrators and developers are familiar with these tools.

--- a/Instructions/03-manage.md
+++ b/Instructions/03-manage.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Manage a vCore-based Azure Cosmos DB for MongoDB account'
-    module: 'Module 3 - Manage vCore-based Azure Cosmos DB for MongoDB'
+  title: Manage a vCore-based Azure Cosmos DB for MongoDB account
+  module: Module 3 - Manage vCore-based Azure Cosmos DB for MongoDB
+  description: In this lab, you learned to manage, scale, monitor, and generate alerts on a vCore-based Azure Cosmos DB for MongoDB account. You used monitoring tools to track operations and generate alerts. You also learned how to scale your account to handle increased or decreased traffic. You can now apply these skills to your own applications and databases.
+  duration: 20 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Cosmos DB
 ---
 
 In this lab, you learn how to manage, scale, monitor, and generate alerts on a vCore-based Azure Cosmos DB for MongoDB account. You use monitoring tools to track operations and scale your account to handle increased or decreased traffic. You learn how to enable diagnostic settings to collect logs and metrics from your Cosmos DB account. You learn how to create alerts to notify you when certain conditions are met. You run a simulated workload to generate some data for your logs and metrics. Finally, you review the logs and metrics that are being generated.

--- a/Instructions/04-vector-search.md
+++ b/Instructions/04-vector-search.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Building an AI copilot using vCore-based Azure Cosmos DB for MongoDB vector search and Azure OpenAI'
-    module: 'Module 4 - Use Azure AI OpenAI and vector search to create AI copilots with vCore-based Azure Cosmos DB for MongoDB'
+  title: Building an AI copilot using vCore-based Azure Cosmos DB for MongoDB vector search and Azure OpenAI
+  module: Module 4 - Use Azure AI OpenAI and vector search to create AI copilots with vCore-based Azure Cosmos DB for MongoDB
+  description: In this lab, you use Azure OpenAI to create embeddings for vCore-based Azure Cosmos DB for MongoDB documents, establishing your AI copilot for advanced data exploration. You build a vector index from these embeddings, allowing you to create vector searches. The vector searches involves generating an embedding for user prompts, using those user prompt embeddings to find similar documents in the database through a vector search, and enhancing the search results deploying an Azure OpenAI GPT-3.5 chat. This process illustrates a Retrieval-Augmented Generation (RAG) approach, mixing AI with database technologies to refine search results and responses.
+  duration: 94 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Cosmos DB
 ---
 
 In this lab, you use Azure OpenAI to create embeddings for vCore-based Azure Cosmos DB for MongoDB documents, establishing your AI copilot for advanced data exploration. You build a vector index from these embeddings, allowing you to create vector searches. The vector searches involves generating an embedding for user prompts, using those user prompt embeddings to find similar documents in the database through a vector search, and enhancing the search results deploying an Azure OpenAI GPT-3.5 chat. This process illustrates a Retrieval-Augmented Generation (RAG) approach, mixing AI with database technologies to refine search results and responses.

--- a/Instructions/05-prepare-copilot-application.md
+++ b/Instructions/05-prepare-copilot-application.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Prepare your copilot application'
-    module: 'Module 5 - Deploy your AI Copilot with Azure Kubernetes '
+  title: Prepare your copilot application
+  module: 'Module 5 - Deploy your AI Copilot with Azure Kubernetes '
+  description: Previously in this learning path, you implemented AI vector search functionality within your MongoDB project. Now this project is extended to include a web application interface. In this exercise, you’ll add code to expose key functions and create endpoints, enabling external interactions with the application. You’ll also create a Dockerfile to containerize your app, then run the Docker image locally to verify everything is working as expected. By the end of this exercise, you create a web application ready for deployment, complete with accessible endpoints, and containerized for easy distribution.
+  duration: 62 minutes
+  level: 400
+  islab: true
 ---
 
 >[!note]

--- a/Instructions/06-create-azure-kubernetes-cluster.md
+++ b/Instructions/06-create-azure-kubernetes-cluster.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Create an Azure Kubernetes Service cluster'
-    module: 'Module 6 - Deploy your AI Copilot with Azure Kubernetes '
+  title: Create an Azure Kubernetes Service cluster
+  module: 'Module 6 - Deploy your AI Copilot with Azure Kubernetes '
+  description: In this exercise, you create an Azure Kubernetes Service (AKS) cluster and deploy an image to the Azure Container Registry (ACR). Afterwards, you can access your app through an external IP address.
+  duration: 54 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Container Registry
+    - Azure Kubernetes Service (AKS)
 ---
 
 >[!note]


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 6

- `Instructions/01-create-account.md` (description,duration,level,islab,primarytopics)
- `Instructions/02-migrate.md` (description,duration,level,islab,primarytopics)
- `Instructions/03-manage.md` (description,duration,level,islab,primarytopics)
- `Instructions/04-vector-search.md` (description,duration,level,islab,primarytopics)
- `Instructions/05-prepare-copilot-application.md` (description,duration,level,islab)
- `Instructions/06-create-azure-kubernetes-cluster.md` (description,duration,level,islab,primarytopics)
